### PR TITLE
Update version info of dependencies for h2o_hf

### DIFF
--- a/h2o_hf/README.md
+++ b/h2o_hf/README.md
@@ -7,9 +7,9 @@
 - PyTorch >= 1.12
 
 ```
-pip install crfm-helm
-pip install git+https://github.com/huggingface/transformers
-pip install lm-eval
+pip install crfm-helm==0.2.3
+pip install transformers==4.28.1
+pip install lm-eval==0.3.0
 ```
 
 


### PR DESCRIPTION
The installation instruction in README.md is outdated, and directly applying it would cause error when running codes. This PR specifies the version requirements of dependencies in README.md, in order to make the code run successfully.